### PR TITLE
Replace docker images by our base images

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,4 +1,8 @@
 FROM 728137396354.dkr.ecr.eu-west-1.amazonaws.com/s24-base-python37:283 as BUILDER
+
+RUN yum install -y zip && \
+    yum clean all && rm -rf /var/cache/yum
+
 WORKDIR /lambda
 
 ADD requirements.txt /tmp

--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,19 +1,18 @@
-FROM python:3.7
-RUN apt-get update && apt-get install -y zip
+FROM 728137396354.dkr.ecr.eu-west-1.amazonaws.com/s24-base-python37:283 as BUILDER
 WORKDIR /lambda
 
 ADD requirements.txt /tmp
-RUN pip install -t /lambda -r /tmp/requirements.txt
+RUN pip3 install -t /lambda -r /tmp/requirements.txt
 
 ADD src/ /lambda/
 RUN find /lambda -type d | xargs -n 1 -I {} chmod ugo+rx "{}" && \
     find /lambda -type f | xargs -n 1 -I {} chmod ugo+r "{}"
 
-RUN python -m compileall -q /lambda
+RUN python3 -m compileall -q /lambda
 
 ARG ZIPFILE=lambda.zip
 RUN zip --quiet -9r /${ZIPFILE}  .
 
-FROM scratch
+FROM 728137396354.dkr.ecr.eu-west-1.amazonaws.com/s24-base:283
 ARG ZIPFILE
-COPY --from=0 /${ZIPFILE} /
+COPY --from=BUILDER /${ZIPFILE} /


### PR DESCRIPTION
We're currently using the official python image and `scratch`: replacing them by our base images.