### PR TITLE
Revert "Update elastic-ip-manager.yaml"

### DIFF
--- a/cloudformation/elastic-ip-manager.yaml
+++ b/cloudformation/elastic-ip-manager.yaml
@@ -110,7 +110,6 @@ Resources:
   OpsGenieTopic:
     Type: AWS::SNS::Topic
     Properties:
-      KmsMasterKeyId: 'alias/aws/sns'
       Subscription:
         - Endpoint: !Sub https://api.opsgenie.com/v1/json/cloudwatch?apiKey=${OpsGenieKey}
           Protocol: https


### PR DESCRIPTION
Reverts Scout24/ec2-elastic-ip-manager#6
Encryption must be done with a customer key, that allows CloudWatch to decrypt the key