### PR TITLE
Update AWS Lambda runtimes from Python 3.9 to 3.14

### DIFF
--- a/cloudformation/elastic-ip-manager.yaml
+++ b/cloudformation/elastic-ip-manager.yaml
@@ -70,7 +70,7 @@ Resources:
         S3Key: !Ref 'CFNCustomProviderZipFileName'
       Handler: elastic_ip_manager.handler
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.14
       Timeout: 600
 
   Permission:


### PR DESCRIPTION
This PR updates the AWS Lambda runtime from python3.9 to python3.11 in CloudFormation templates.
https://linear.app/scout24-se/issue/DP-233/list-or-fix-lambda-functions-with-runtime-python-39